### PR TITLE
Latest pipenv updates breaks builds and tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,6 @@ deps = pipenv
 
 [testenv:tests]
 commands =
-    pipenv install --dev --skip-lock
+    pipenv install --dev
     pipenv run pip freeze
     pytest tests

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ filterwarnings =
 
 [testenv]
 allowlist_externals = pytest
-deps = pipenv
+deps = pipenv==2023.7.23
 
 [testenv:tests]
 commands =


### PR DESCRIPTION
Remove pipenv's skip-lock obsolete option